### PR TITLE
Improve reading of config file

### DIFF
--- a/bin/gqlint.js
+++ b/bin/gqlint.js
@@ -34,15 +34,14 @@ function getGQLintConfig() {
   let data;
 
   try {
-    let { data } = fs.readFileSync(program.config, { encoding: 'utf8' });
+    data = fs.readFileSync(program.config, { encoding: 'utf8' });
   } catch (e) {
-    console.error('Running with default config.');
+    console.error('Found no config file, running with default config.');
     return;
   }
 
   try {
-    const json = JSON.parse(data);
-    return json;
+    return JSON.parse(data);
   } catch (e) {
     console.error('Could not parse .gqlint file.');
     throw e;


### PR DESCRIPTION
As part of refactoring a GraphQL server I wanted to focus on getting the GraphQL Schema into the best shape possible and what better tool to help in that, and to ensure that it sticks that way, than a linter? So I was very happy to find that someone had started on making a linter for GraphQL Schemas, very handy!

I did however run across an error with the CLI command and tracked it down to an erroneous expectation of the return data from `fs.readFileSync()`. When an encoding has been specified, as it has in this case, then it returns a string: https://nodejs.org/api/fs.html#fs_fs_readfilesync_path_options

Due to this wrong expectation the defined config file wasn't used but instead a JSON parse error was given whenever a config file was defined.

As an additional fix I reworded the error message to actually note the reason to why it will run with the default config + removed a needless assign to a `json` const. I hope that's okay and not stretching it too far for a single PR.