### PR TITLE
Proposal: Allow underscores in enum values

### DIFF
--- a/rules/enum.casing.js
+++ b/rules/enum.casing.js
@@ -1,5 +1,5 @@
 const { visit, getLocation } = require('graphql/language');
-const { upperCase } = require('lodash');
+const { toUpper } = require('lodash');
 
 const getMessage = (text, node) => {
   const message = `Property '${node.name
@@ -24,7 +24,7 @@ module.exports = function(ast, text) {
 
       visit(node, {
         EnumValueDefinition(node) {
-          const uppercased = upperCase(node.name.value);
+          const uppercased = toUpper(node.name.value);
           if (uppercased !== node.name.value) {
             valid = false;
           }


### PR DESCRIPTION
Lodash's `upperCase` method will convert all underscores to spaces. So, an enum value of "NOT_CERTIFIED" will get changed to "NOT CERTIFIED" which will not match and cause the lint check to fail. Alternatively, if we use the `toUpper` method, the underscores will be preserved and the lint check will pass.