### PR TITLE
fix mutation name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gqlint",
-  "version": "1.6.1",
+  "version": "1.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,12 @@
   "name": "gqlint",
   "version": "1.8.0",
   "description": "GraphQL Linter",
-  "keywords": ["graphql", "gql", "lint", "linter"],
+  "keywords": [
+    "graphql",
+    "gql",
+    "lint",
+    "linter"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/happylinks/gqlint.git"
@@ -14,7 +19,10 @@
     "precommit": "lint-staged"
   },
   "lint-staged": {
-    "*.js": ["prettier --single-quote --write", "git add"]
+    "*.js": [
+      "prettier --single-quote --write",
+      "git add"
+    ]
   },
   "bin": {
     "gqlint": "./bin/gqlint.js"

--- a/rules/removedelete.mutations.js
+++ b/rules/removedelete.mutations.js
@@ -63,7 +63,10 @@ function getMutationNames(ast) {
 
   visit(ast, {
     ObjectTypeExtension(node) {
-      if (node.name.value !== 'Mutation') {
+      if (
+        node.name.value !== 'Mutation' ||
+        node.name.value === 'GraphQLMutation'
+      ) {
         return;
       }
       visit(node, {
@@ -73,7 +76,10 @@ function getMutationNames(ast) {
       });
     },
     ObjectTypeDefinition(node) {
-      if (node.name.value === 'Mutation') {
+      if (
+        node.name.value === 'Mutation' ||
+        node.name.value === 'GraphQLMutation'
+      ) {
         mutationNames.push(node.name.value);
       }
     }

--- a/rules/removedelete.mutations.js
+++ b/rules/removedelete.mutations.js
@@ -58,12 +58,37 @@ const checkWrongName = (text, node, messages, name) => {
   }
 };
 
+function getMutationNames(ast) {
+  const mutationNames = [];
+
+  visit(ast, {
+    ObjectTypeExtension(node) {
+      if (node.name.value !== 'Mutation') {
+        return;
+      }
+      visit(node, {
+        FieldDefinition(node) {
+          mutationNames.push(node.type.name.value);
+        }
+      });
+    },
+    ObjectTypeDefinition(node) {
+      if (node.name.value === 'Mutation') {
+        mutationNames.push(node.name.value);
+      }
+    }
+  });
+  return mutationNames;
+}
+
 module.exports = function(ast, text) {
   const messages = [];
 
+  const mutationNames = getMutationNames(ast);
+
   visit(ast, {
     ObjectTypeDefinition(node) {
-      if (node.name.value !== 'GraphQLMutation') {
+      if (mutationNames.indexOf(node.name.value) < 0) {
         return;
       }
 

--- a/rules/singular.mutations.js
+++ b/rules/singular.mutations.js
@@ -19,12 +19,37 @@ const getMessage = (text, name, start) => {
   };
 };
 
+function getMutationNames(ast) {
+  const mutationNames = [];
+
+  visit(ast, {
+    ObjectTypeExtension(node) {
+      if (node.name.value !== 'Mutation') {
+        return;
+      }
+      visit(node, {
+        FieldDefinition(node) {
+          mutationNames.push(node.type.name.value);
+        }
+      });
+    },
+    ObjectTypeDefinition(node) {
+      if (node.name.value === 'Mutation') {
+        mutationNames.push(node.name.value);
+      }
+    }
+  });
+  return mutationNames;
+}
+
 module.exports = function(ast, text) {
   const messages = [];
 
+  const mutationNames = getMutationNames(ast);
+
   visit(ast, {
     ObjectTypeDefinition(node) {
-      if (node.name.value !== 'GraphQLMutation') {
+      if (mutationNames.indexOf(node.name.value) < 0) {
         return;
       }
 

--- a/rules/singular.mutations.js
+++ b/rules/singular.mutations.js
@@ -24,7 +24,10 @@ function getMutationNames(ast) {
 
   visit(ast, {
     ObjectTypeExtension(node) {
-      if (node.name.value !== 'Mutation') {
+      if (
+        node.name.value !== 'Mutation' ||
+        node.name.value === 'GraphQLMutation'
+      ) {
         return;
       }
       visit(node, {
@@ -34,7 +37,10 @@ function getMutationNames(ast) {
       });
     },
     ObjectTypeDefinition(node) {
-      if (node.name.value === 'Mutation') {
+      if (
+        node.name.value === 'Mutation' ||
+        node.name.value === 'GraphQLMutation'
+      ) {
         mutationNames.push(node.name.value);
       }
     }


### PR DESCRIPTION
Mutations were previously found using the keyword "GraphQLMutation", while users do not always follow this rule. They can, however, follow this pattern: 

extend type Mutation {
  users: UserMutation
}

type UserMutation {
  createUsers(email: String): User
}

This pull request fixes that problem. I first find what are the mutations that we have, then run the previously implemented analysis 